### PR TITLE
should run test db ONLY

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack -p 3007",
+    "dev": "cross-env NODE_ENV=test next dev --turbopack -p 3007",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "cross-env NODE_ENV=test storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test:api": "cd ./tests/newman && cross-env NODE_ENV=test newman run auth.json --reporter-cli-no-console",
     "test:frontend": "cross-env NODE_ENV=test jest --selectProjects frontend --verbose",


### PR DESCRIPTION
-discontinue usage of prod db

### Type

why type of pr is this for?

- fix


### Summary

i did a thing the things were:

- changed so that it runs on test db always

### Details

![image](https://github.com/user-attachments/assets/4114682b-e20a-4b2d-bec5-d393e2b9222a)


## Notes

- discontinue the usage of PROD db in DEV mode or in storybook or test environment
