### PR TITLE
 Testing/Auth E2E additionas

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -41,6 +41,15 @@ export default defineConfig({
           }
           return user.session
         },
+        resetLoginAttempts: async (email) => {
+          const { error } = await supabase.rpc('reset_failed_attempts', {
+            user_email: email,
+          })
+          if (error) {
+            throw new Error('Failed to reset login attempts')
+          }
+          return null
+        },
       })
 
       return config

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "jsx": "react-jsx",
+    "target": "es5",
+    "lib": ["es5", "dom"],
     "sourceMap": true,
     "types": ["cypress", "node"]
-  }
+  },
+  "include": ["**/*.ts"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^14.6.1",
+        "@types/cypress": "^1.1.6",
         "@types/jest": "^29.5.14",
         "@types/node": "^20",
         "@types/react": "^19.0.12",
@@ -7554,6 +7555,16 @@
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/cypress": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-1.1.6.tgz",
+      "integrity": "sha512-CfeLLD3+6vIWe2AO5hR63f1c8EbRzrp/j1ExubAwOTpwZFZvF3Nm9cOPQiUwzNmAUmZuhO0QVH98Qlujni6nPw==",
+      "deprecated": "This is a stub types definition. cypress provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "cypress": "*"
+      }
     },
     "node_modules/@types/doctrine": {
       "version": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/cypress": "^1.1.6",
     "@types/jest": "^29.5.14",
     "@types/node": "^20",
     "@types/react": "^19.0.12",


### PR DESCRIPTION
### Trello Link Reference
https://trello.com/c/ftRpkX7K/173-refactortestauth-cover-the-remaining-auth-refactors-in-cypress
### Type

why type of pr is this for?

- fix
- refactor

### Summary

i did a thing the things were:

- covered the additional coverage from the auth refactor fix
- added notes and more tasks
- added the tsconfig inside the cypress folder according to cypress docs [(see here)](https://docs.cypress.io/app/tooling/typescript-support#Install-TypeScript)

### Details

- added a task that resets the fail counter automatically
![image](https://github.com/user-attachments/assets/0b4f58b4-3cfb-4cee-88f0-b52ee53421cc)

- added test coverage from auth refactor update
![image](https://github.com/user-attachments/assets/43ae665b-56bb-4c3e-8d92-5d9677049a4d)

- tsconfig inside cypress folder for types
![image](https://github.com/user-attachments/assets/57bdebad-4d70-465b-96b7-e7d4cadfd6fd)



## Notes

- although i run the delete function task for the user after all my tests, it is encouraged you comment this out and use the created test user to navigate through the other tests like (matters, tasks, bills) instead of creating a user everytime
![image](https://github.com/user-attachments/assets/25f58c60-fdeb-442f-95ca-fb10c21ab30a)

