### PR TITLE
Fix/Global Search Mobile UI

### DIFF
--- a/src/components/header/globalSearch/searchDialog.tsx
+++ b/src/components/header/globalSearch/searchDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { Search } from 'lucide-react'
+import { Search, XIcon } from 'lucide-react'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
@@ -177,20 +177,20 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
       <DialogTitle className="sr-only">Search Dialog</DialogTitle>
       <DialogContent
         role="dialog"
-        className="w-[calc(100%-2rem)] sm:max-w-xl max-h-[90vh] p-4 sm:p-6 overflow-hidden"
+        className="w-[calc(100%-2rem)] sm:max-w-xl max-h-[90vh] p-4 sm:p-6 overflow-hidden bg-accent"
       >
         {/* Make the entire content area scrollable */}
         <div className="max-h-[calc(90vh-2rem)] overflow-y-auto pr-2">
           {/* Search input area - sticky at the top */}
-          <div className="flex items-center border-b border-border pb-4 sticky top-0 bg-background z-10">
-            <Search className="h-5 w-5 text-muted-foreground mr-2 flex-shrink-0" />
+          <div className="flex items-center border-b border-border pb-4 sticky top-0  z-10">
+            <Search className="h-5 w-5 text-muted-foreground mr-2 flex-shrink-0 hidden sm:block" />
             <Input
               aria-label="DialogBoxSearch"
               ref={inputRef}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder="Search for matters, bills, tasks..."
-              className="border-0 p-0 focus-visible:ring-0 text-lg flex-1 text-foreground placeholder:text-muted-foreground"
+              className="border-0 p-0 focus-visible:ring-0 text-lg flex-1 text-foreground placeholder:text-muted-foreground placeholder:text-xs sm:placeholder:text-sm "
             />
             <Button
               variant="outline"
@@ -199,7 +199,10 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
               onClick={handleClearSearch}
               className="ml-2 whitespace-nowrap"
             >
-              Clear
+              <span className="hidden sm:block">Clear</span>
+              <span>
+                <XIcon />
+              </span>
             </Button>
           </div>
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { XIcon } from 'lucide-react'
+// import { XIcon } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,10 +1,10 @@
-"use client"
+'use client'
 
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { XIcon } from "lucide-react"
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { XIcon } from 'lucide-react'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
 function Dialog({
   ...props
@@ -38,7 +38,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
         className
       )}
       {...props}
@@ -57,14 +57,14 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
           className
         )}
         {...props}
       >
         {children}
         <DialogPrimitive.Close className="cursor-pointer ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
-          <XIcon />
+          {/* <XIcon /> */}
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>
       </DialogPrimitive.Content>
@@ -72,22 +72,22 @@ function DialogContent({
   )
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
       {...props}
     />
   )
 }
 
-function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-footer"
       className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
         className
       )}
       {...props}
@@ -102,7 +102,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn('text-lg leading-none font-semibold', className)}
       {...props}
     />
   )
@@ -115,7 +115,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
   )


### PR DESCRIPTION
### Trello Link Reference
https://trello.com/c/LmOWoiEn/185-refactorsearch-fix-mobile-ui-for-gs
### Type

why type of pr is this for?

- fix
- refactor

### Summary

i did a thing the things were:


- change the icons that show and improved spacing for the gs component
- also changed colors 
- removed the extra close button on top 

### Details

- desktop view light mode
![image](https://github.com/user-attachments/assets/8ca32cc4-913b-4e73-bbc8-c38b2e915cd4)
- mobile view (icons disappear and placeholder text resizes)
![image](https://github.com/user-attachments/assets/eede382a-4822-41a7-9fb5-539795631a03)

- dark mode uses bg-accent instead of bg-background
![image](https://github.com/user-attachments/assets/a1399fab-97d1-4326-a5c6-28680bd1a894)


## Notes
-none
