### PR TITLE
Fix/ Super Minor adjustments with spelling

### DIFF
--- a/cypress/e2e/auth.cy.ts
+++ b/cypress/e2e/auth.cy.ts
@@ -52,7 +52,7 @@ describe('User Auth Process', () => {
       cy.get('#password').type('testPassword')
       cy.contains('Sign Up').click()
       cy.wait(2000)
-        .contains('Sign Up Succesful! Confirm your Emeil!')
+        .contains('Sign Up Succesful! Confirm your Email!')
         .should('be.visible')
     })
     it('should throw an error if the user tries to sign up with the same credentials while the confirmation email was not confirmed ', () => {

--- a/src/components/header/globalSearch/searchByFilters.tsx
+++ b/src/components/header/globalSearch/searchByFilters.tsx
@@ -115,7 +115,7 @@ export function SearchByFilters({ filters, setFilters }: SearchByFiltersProps) {
               htmlFor="opposingCouncil"
               className="text-sm text-foreground"
             >
-              Opposing Counsel
+              Opposing Council
             </label>
           </div>
 


### PR DESCRIPTION

### Type

why type of pr is this for?

- fix


### Summary

i did a thing the things were:

- 'Emeil' to 'Email' in my cypress test 
- changed back counsel to council to mantain uniformity

### Details
![image](https://github.com/user-attachments/assets/a0b1e75a-446b-427a-a8c3-be30ee8ce0fa)




## Notes

- need spelling checks lol
